### PR TITLE
Added style to text_to_speech method

### DIFF
--- a/lib/elevenlabs/client.rb
+++ b/lib/elevenlabs/client.rb
@@ -8,6 +8,7 @@ module Elevenlabs
     
     ELEVENLABS_FQDN = 'https://api.elevenlabs.io'
     DEFAULT_STABILITY = 0.5
+    DEFAULT_STYLE = 0.5
     DEFAULT_MODEL = 'eleven_monolingual_v1'
     attr_accessor :api_key
 
@@ -17,14 +18,15 @@ module Elevenlabs
       @api_key = api_key
     end
 
-    def text_to_speech(voice_id:, optimize_streaming_latency: 0, text:, stability: DEFAULT_STABILITY, model: DEFAULT_MODEL, stream: false)
+    def text_to_speech(voice_id:, optimize_streaming_latency: 0, text:, style: DEFAULT_STYLE, stability: DEFAULT_STABILITY, model: DEFAULT_MODEL, stream: false)
       
       body = {
         text: text,
         model_id: model,
         voice_settings: {
           stability: stability,
-          similarity_boost: 0
+          similarity_boost: 0,
+          style: style
         }
       }
       url_path = stream ? "#{ELEVENLABS_FQDN}/v1/text-to-speech/#{voice_id}/stream" : "#{ELEVENLABS_FQDN}/v1/text-to-speech/#{voice_id}"


### PR DESCRIPTION
This adds style to the text_to_speech method, according to elevenlabs documentation: 

<img width="1215" alt="Zrzut ekranu 2024-06-11 o 17 22 09" src="https://github.com/nodanaonlyzuul/elevenlabs-rb/assets/396706/743a6bc4-58fc-4e24-ae47-ed16860a39ae">

I set it to 50%, because this is the value I prefer, but I'm open to adjust it.